### PR TITLE
fix: config ID precision loss in telemetry reporting

### DIFF
--- a/src/__tests__/telemetry/evaluationSummaries.test.ts
+++ b/src/__tests__/telemetry/evaluationSummaries.test.ts
@@ -356,4 +356,32 @@ describe("evaluationSummaries", () => {
       );
     });
   });
+
+  it("preserves large config IDs without precision loss", async () => {
+    const largeConfigId = Long.fromString("17537369033474523");
+    const largeConfig: Config = {
+      ...basicConfig,
+      id: largeConfigId,
+    };
+
+    const aggregator = evaluationSummaries(
+      mockApiClient,
+      telemetrySource,
+      instanceHash,
+      true
+    );
+
+    aggregator.push(evaluationFor(largeConfig, usContexts));
+
+    const syncResult = await aggregator.sync();
+
+    if (syncResult === undefined) {
+      throw new Error("syncResult is undefined");
+    }
+
+    const counter =
+      syncResult.dataSent.events[0].summaries?.summaries[0].counters[0];
+    expect(counter?.configId?.toString()).toBe("17537369033474523");
+    expect(counter?.configId?.equals(largeConfigId)).toBe(true);
+  });
 });

--- a/src/telemetry/evaluationSummaries.ts
+++ b/src/telemetry/evaluationSummaries.ts
@@ -144,7 +144,7 @@ export const evaluationSummaries = (
           }
 
           const counter: ConfigEvaluationCounter = {
-            configId: Long.fromNumber(configId),
+            configId: Long.fromString(configId),
             conditionalValueIndex,
             configRowIndex,
             selectedValue,


### PR DESCRIPTION
##  Description

Ported from https://github.com/prefab-cloud/prefab-cloud-node/pull/108

  Fixes a JavaScript precision issue where large config IDs lose accuracy during telemetry reporting. Config ID 17537369033474523 was being reported as 17537369033474524 due to JavaScript's number precision limits.

 ### Root Cause:
  The telemetry system serializes evaluation data to JSON for aggregation, then deserializes it before sending to the API. During JSON.parse(), numeric strings in arrays are automatically converted to JavaScript numbers. For integers larger than Number.MAX_SAFE_INTEGER (2^53 - 1), this causes precision loss.

###  The Fix:
  Changed Long.fromNumber(configId) to Long.fromString(configId) in the telemetry counter deserialization logic. This preserves the exact string representation throughout the JSON round-trip, avoiding JavaScript number precision issues.

##  Testing

  - Added regression test that verifies config ID 17537369033474523 is preserved exactly during telemetry processing
  - All existing telemetry tests continue to pass
  - Full test suite passes (519 tests)
  - Lint and format checks pass

  The fix is minimal and targeted, only affecting the specific conversion point where precision was being lost.