### PR TITLE
Add support for ALWAYS_TRUE rule evaluation

### DIFF
--- a/src/__tests__/evaluate.test.ts
+++ b/src/__tests__/evaluate.test.ts
@@ -873,6 +873,77 @@ describe("evaluate", () => {
       `No value found for key '${decryptionKeyForSecret(secret)}'`
     );
   });
+
+  it("returns an evaluation for an ALWAYS_TRUE match", () => {
+    const alwaysTrueConfig: Config = {
+      id: "always-true-test",
+      project_id: projectEnvIdUnderTest,
+      key: "always.true.test",
+      changed_by: undefined,
+      rows: [
+        {
+          properties: {},
+          project_env_id: projectEnvIdUnderTest,
+          values: [
+            {
+              criteria: [
+                {
+                  property_name: "irrelevant.property",
+                  operator: Criterion_CriterionOperator.AlwaysTrue,
+                  value_to_match: undefined,
+                },
+              ],
+              value: {
+                string: "always-true-result",
+              },
+            },
+            {
+              criteria: [],
+              value: {
+                string: "default",
+              },
+            },
+          ],
+        },
+      ],
+      allowable_values: [],
+      config_type: ConfigType.Config,
+      value_type: ConfigValueType.String,
+      send_to_client_sdk: false,
+    };
+
+    const args = (contexts: Contexts): EvaluateArgs => ({
+      config: alwaysTrueConfig,
+      projectEnvId: projectEnvIdUnderTest,
+      namespace: noNamespace,
+      contexts,
+      resolver: simpleResolver,
+    });
+
+    expect(evaluate(args(emptyContexts))).toStrictEqual({
+      configId: alwaysTrueConfig.id,
+      configKey: alwaysTrueConfig.key,
+      configType: alwaysTrueConfig.config_type,
+      valueType: alwaysTrueConfig.value_type,
+      unwrappedValue: "always-true-result",
+      reportableValue: undefined,
+      configRowIndex: 0,
+      conditionalValueIndex: 0,
+      weightedValueIndex: undefined,
+    });
+
+    expect(evaluate(args(usContexts))).toStrictEqual({
+      configId: alwaysTrueConfig.id,
+      configKey: alwaysTrueConfig.key,
+      configType: alwaysTrueConfig.config_type,
+      valueType: alwaysTrueConfig.value_type,
+      unwrappedValue: "always-true-result",
+      reportableValue: undefined,
+      configRowIndex: 0,
+      conditionalValueIndex: 0,
+      weightedValueIndex: undefined,
+    });
+  });
 });
 
 describe.each([

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -367,6 +367,8 @@ const allCriteriaMatch = (
           contexts,
           (compareResult) => compareResult > 0
         );
+      case Criterion_CriterionOperator.AlwaysTrue:
+        return true;
       default:
         throw new Error(
           `Unexpected criteria ${jsonStringifyWithBigInt(criterion.operator)}`


### PR DESCRIPTION
## Summary
- Added missing case for `Criterion_CriterionOperator.AlwaysTrue` in the rule evaluator switch statement
- Added comprehensive test coverage for the `ALWAYS_TRUE` criterion
- The `ALWAYS_TRUE` enum value already existed in types but wasn't handled in evaluation logic

## Changes
- **src/evaluate.ts**: Added case for `AlwaysTrue` that returns `true`
- **src/__tests__/evaluate.test.ts**: Added test that verifies `ALWAYS_TRUE` rule always matches regardless of context

## Test plan
- [x] Added unit test that exercises `ALWAYS_TRUE` rule without remote calls
- [x] Test verifies rule returns expected value with both empty and populated contexts
- [x] All existing evaluate tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)