### PR TITLE
fix: export SchemaType as object, not type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.3 - 2025-10-02
+
+- fix: export SchemaType as object, not type
+
 ## 0.0.2 - 2025-10-02
 
 - fix: correct string list in config value types

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "yarn@4.9.2",
   "name": "@reforge-com/node",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Feature Flags, Live Config, and Dynamic Log Levels",
   "main": "dist/reforge.cjs",
   "types": "dist/reforge.d.ts",

--- a/src/reforge.ts
+++ b/src/reforge.ts
@@ -542,7 +542,7 @@ export {
   type ConfigRow,
   type ConfigValue,
   type Contexts,
-  type SchemaType,
+  SchemaType,
   type Provided,
   type Resolver,
 };


### PR DESCRIPTION
## Description

fix: export SchemaType as object, not type
