### PR TITLE
chore: remove NPM_TOKEN from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,8 +53,6 @@ jobs:
       id-token: write
     outputs:
       published-version: ${{ needs.check-version.outputs.current-version }}
-    env:
-      NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       # Setup .npmrc file to publish to npm


### PR DESCRIPTION
## Summary
- Removes the `NPM_AUTH_TOKEN` environment variable from the release workflow
- Workflow now uses npm trusted publishing (OIDC) authentication exclusively

## Context
We've switched to npm's trusted publisher feature, which uses GitHub's OIDC authentication instead of long-lived tokens. The workflow already has the required configuration:
- `id-token: write` permission
- `--provenance` flag on publish commands

The `NPM_TOKEN` secret is no longer needed and should be removed from GitHub secrets after this PR is merged.

## Benefits
- Eliminates long-lived token management
- Reduces risk of token leakage
- Aligns with npm's 2025 security improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)