### PR TITLE
chore: update to yarn 4.11.0 and configure for trusted publisher

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: enable corepack
         run: |
           corepack enable
-          corepack prepare yarn@4.9.2 --activate
+          corepack prepare yarn@4.11.0 --activate
       - name: cache yarn dependencies
         uses: actions/cache@v4
         with:
@@ -76,9 +76,9 @@ jobs:
       - name: Publish to npm
         run: |
           if [ "${{ needs.check-version.outputs.is-prerelease }}" == "true" ]; then
-            yarn npm publish --provenance --access public --tag ${{ needs.check-version.outputs.npm-tag }}
+            yarn npm publish --access public --tag ${{ needs.check-version.outputs.npm-tag }}
           else
-            yarn npm publish --provenance --access public
+            yarn npm publish --access public
           fi
 
   create-release:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,3 @@
 nodeLinker: node-modules
+npmPublishProvenance: true
 npmRegistryServer: 'https://registry.npmjs.org'
-npmAuthToken: '${NPM_AUTH_TOKEN}'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "yarn@4.9.2",
+  "packageManager": "yarn@4.11.0",
   "name": "@reforge-com/node",
   "version": "0.1.0",
   "description": "Feature Flags, Live Config, and Dynamic Log Levels",


### PR DESCRIPTION
## Summary
- Updates yarn from 4.9.2 to 4.11.0 in release workflow
- Removes `--provenance` flag from publish commands (now handled by .yarnrc.yml)
- Removes `npmAuthToken` from .yarnrc.yml (using OIDC instead)
- Keeps `npmPublishProvenance: true` in .yarnrc.yml for automatic provenance generation

## Context
Yarn 4.11.0 is required for proper npm trusted publisher support with OIDC authentication. With `npmPublishProvenance: true` set in .yarnrc.yml, provenance is automatically enabled and the `--provenance` CLI flag is redundant.

The workflow will now authenticate using GitHub's OIDC token (via `id-token: write` permission) and automatically generate provenance attestations through the yarn configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)